### PR TITLE
update go version to 1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kentik/api-schema-public
 
-go 1.18
+go 1.24
 
 require (
 	github.com/golang/protobuf v1.5.3


### PR DESCRIPTION
go version >= 1.20 required for some newly generated protobuf code